### PR TITLE
fix spanish translation Localizable.xcstrings

### DIFF
--- a/src/i18n/Localizable.xcstrings
+++ b/src/i18n/Localizable.xcstrings
@@ -10428,7 +10428,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ayudar"
+            "value" : "Ayuda"
           }
         },
         "fr" : {


### PR DESCRIPTION
Fix “help” translation in spanish, Ayudar is like “to help” it is the verb in infinitive. “Ayuda” is better