### PR TITLE
Fix copying complete terminal lines on macOS

### DIFF
--- a/src/ssh/assets/xterm-webssh.js
+++ b/src/ssh/assets/xterm-webssh.js
@@ -573,20 +573,33 @@ const TerminalHelper = {
         terminal.scrollToBottom();
     },
 
-    copySelectedText: debounce(() => {
-        // An empty selection must never reach the clipboard : entering an alternate
-        // screen app (vi, ...) clears the selection and would flush the copy buffer.
-        if (TerminalHelper.lastSelectedText == null || TerminalHelper.lastSelectedText === '') {
-            return;
-        }
+    copySelectedText: (() => {
+        const notifyCopyTextSelection = debounce((textSelection) => {
+            JS2IOS.calliOSFunction('notifyCopyTextSelection', [Base64.utoa(textSelection)]);
 
-        JS2IOS.calliOSFunction('notifyCopyTextSelection', [Base64.utoa(TerminalHelper.lastSelectedText)]);
+            if (TerminalHelper.endCopySelectedTextCallback) {
+                TerminalHelper.endCopySelectedTextCallback();
+                TerminalHelper.endCopySelectedTextCallback = null;
+            }
+        }, navigator.platform.startsWith('Mac') ? 1 : 250);
 
-        if (TerminalHelper.endCopySelectedTextCallback) {
-            TerminalHelper.endCopySelectedTextCallback();
-            TerminalHelper.endCopySelectedTextCallback = null;
-        }
-    }, navigator.platform.startsWith('Mac') ? 1 : 250),
+        return () => {
+            // Capture the selection before debouncing. xterm.js can emit another
+            // selection-change event at a line boundary before the delayed callback
+            // runs, which used to replace lastSelectedText with an empty string.
+            const currentSelection = TerminalHelper.exportSelectedText();
+            const textSelection = currentSelection || TerminalHelper.lastSelectedText;
+
+            // An empty selection must never reach the clipboard : entering an alternate
+            // screen app (vi, ...) clears the selection and would flush the copy buffer.
+            if (textSelection == null || textSelection === '') {
+                return;
+            }
+
+            TerminalHelper.lastSelectedText = textSelection;
+            notifyCopyTextSelection(textSelection);
+        };
+    })(),
 
     copyScreenContent: function () {
         TerminalHelper.canNotifySelectionChange = false;


### PR DESCRIPTION
## Problem

On macOS, copying selected text from an active SSH terminal fails when the selection ends exactly at a complete line boundary.

### Steps to reproduce

1. Open a connected SSH session on macOS.
2. Select one or more complete terminal lines with the mouse, including the end of the final line.
3. Press `Cmd+C`.
4. Paste into another application with `Cmd+V`.

Nothing is pasted. If the final line is selected only partially, copying works as expected.

## Root cause

`TerminalHelper.copySelectedText` was debounced and read the mutable global `TerminalHelper.lastSelectedText` only when the delayed callback ran.

At a complete line boundary, xterm.js can emit another selection-change event before that callback executes. That event can replace `lastSelectedText` with an empty string, causing the clipboard notification to return early. The selected text is therefore lost even though it was valid when the user pressed `Cmd+C`.

## Solution

Capture the current xterm.js selection synchronously when `copySelectedText` is invoked, then pass that immutable snapshot into the debounced native clipboard notification.

The change also:

- keeps `lastSelectedText` as a fallback for platforms where selection updates arrive asynchronously;
- preserves the existing protection against clearing the clipboard for genuinely empty selections, such as when entering an alternate-screen application;
- keeps the existing macOS and iOS debounce timings unchanged;
- retains the existing completion callback behavior used by Copy Screen and Copy All.

## Verification

- `node --check src/ssh/assets/xterm-webssh.js`
- `git diff --check`
- Regression harness simulating a complete selection ending with a newline, followed by an empty selection-change event before the delayed callback. The native bridge receives the original complete selection snapshot.

The full native macOS application is not part of this public repository, so final integration verification should be performed in the app build.
